### PR TITLE
feat: allow HCL files to trigger

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,7 +92,7 @@ export function getModulePaths<T extends Record<string, unknown>>(
     ) {
       return paths
     }
-    if (ext === '.tf' || base === '.terraform.lock.hcl') {
+    if (ext === '.tf' || ext === '.hcl' || base === '.terraform.lock.hcl') {
       paths.push(dir)
     }
     return paths


### PR DESCRIPTION
I added HCL extensions to be pushed into the list of recognized file types. 

Background: we use [Terraform module registry](https://github.com/TierMobility/boring-registry) which uses a `hcl` config file. In a nutshell this file contains the module version and we need it as a build trigger as well.

Would be awesome if you could integrate this tiny change. Thanks in advance!

