### PR TITLE
`Feat:` add `pull_request_review` GHA event type

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -198,6 +198,7 @@ function getSha(token) {
         let head;
         switch (github_1.context.eventName) {
             case 'pull_request_target':
+            case 'pull_request_review':
             case 'pull_request': {
                 const payload = github_1.context.payload;
                 base = (_b = (_a = payload.pull_request) === null || _a === void 0 ? void 0 : _a.base) === null || _b === void 0 ? void 0 : _b.sha;


### PR DESCRIPTION
Issue #247 
Adding support for newer GHA event type `pull_request_review` .
This tests/works ok for my use-case where this event type is what triggers the workflow.